### PR TITLE
Add the posibility of disabling the Payment step of the checkout process

### DIFF
--- a/cartridge/project_template/settings.py
+++ b/cartridge/project_template/settings.py
@@ -27,6 +27,9 @@
 # completion.
 # SHOP_CHECKOUT_STEPS_CONFIRMATION = True
 
+# If False, there is no payment step on the checkout process.
+# SHOP_PAYMENT_STEP_ENABLED = True
+
 # Controls the formatting of monetary values accord to the locale
 # module in the python standard library. If an empty string is
 # used, will fall back to the system's locale.

--- a/cartridge/shop/checkout.py
+++ b/cartridge/shop/checkout.py
@@ -111,8 +111,9 @@ CHECKOUT_STEP_FIRST = CHECKOUT_STEP_PAYMENT = CHECKOUT_STEP_LAST = 1
 if settings.SHOP_CHECKOUT_STEPS_SPLIT:
     CHECKOUT_STEPS[0].update({"url": "billing-shipping",
                               "title": _("Address")})
-    CHECKOUT_STEPS.append({"template": "payment", "url": "payment",
-                           "title": _("Payment")})
+    if settings.SHOP_PAYMENT_STEP_ENABLED:
+        CHECKOUT_STEPS.append({"template": "payment", "url": "payment",
+                                "title": _("Payment")})
     CHECKOUT_STEP_PAYMENT = CHECKOUT_STEP_LAST = 2
 if settings.SHOP_CHECKOUT_STEPS_CONFIRMATION:
     CHECKOUT_STEPS.append({"template": "confirmation", "url": "confirmation",

--- a/cartridge/shop/defaults.py
+++ b/cartridge/shop/defaults.py
@@ -111,6 +111,14 @@ register_setting(
 )
 
 register_setting(
+    name="SHOP_PAYMENT_STEP_ENABLED",
+    label=_("Payment Enabled"),
+    description="If False, there is no payment step on the checkout process.",
+    editable=True,
+    default=True,
+)
+
+register_setting(
     name="SHOP_CURRENCY_LOCALE",
     label=_("Currency Locale"),
     description="Controls the formatting of monetary values accord to "

--- a/cartridge/shop/forms.py
+++ b/cartridge/shop/forms.py
@@ -318,6 +318,9 @@ class OrderForm(FormsetForm, DiscountForm):
             elif step == checkout.CHECKOUT_STEP_PAYMENT:
                 # Hide the non-cc fields for payment if steps are split.
                 hidden = lambda f: not f.startswith("card_")
+        elif not settings.SHOP_PAYMENT_STEP_ENABLED:
+            # Hide all the cc fields if payment step is not enabled.
+            hidden = lambda f: f.startswith("card_")
         if settings.SHOP_CHECKOUT_STEPS_CONFIRMATION and last:
             # Hide all fields for the confirmation step.
             hidden = lambda f: True

--- a/cartridge/shop/templates/shop/billing_shipping.html
+++ b/cartridge/shop/templates/shop/billing_shipping.html
@@ -27,8 +27,7 @@
 	<div id="shipping_fields">{% fields_for form.shipping_detail_fields %}</div>
 	{% fields_for form.additional_instructions_field %}
 </fieldset>
-
-{% if not settings.SHOP_CHECKOUT_STEPS_SPLIT %}
+{% if not settings.SHOP_CHECKOUT_STEPS_SPLIT and settings.SHOP_PAYMENT_STEP_ENABLED %}
 {% include "shop/includes/payment_fields.html" %}
 {% endif %}
 

--- a/cartridge/shop/templates/shop/confirmation.html
+++ b/cartridge/shop/templates/shop/confirmation.html
@@ -24,7 +24,7 @@
 	    {% endfor %}
 	</ul>
 </fieldset>
-
+{% if settings.SHOP_PAYMENT_STEP_ENABLED %}
 {% comment %}
 <br clear="all">
 <fieldset class="confirmation">
@@ -49,6 +49,7 @@
 	</ul>
 </fieldset>
 {% endcomment %}
+{% endif %}
 <br clear="all">
 
 {% for field in form %}{{ field }}{% endfor %}


### PR DESCRIPTION
Added a setting for disabling the payment step in the checkout process. The setting is called SHOP_PAYMENT_STEP_ENABLED, and its default value is True, so by default the shop will show the payment step. 

If this setting is set to False the payment step is not show (whenever the checkout steps are split or not) allowing a order-only shop. The payment fields are also hidden in the confirmation step.  
