### PR TITLE
Issue #24: Exception handling in Sale.save().

### DIFF
--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -703,13 +703,13 @@ class Sale(Discount):
                     #
                     # http://dev.mysql.com/
                     # doc/refman/5.0/en/subquery-errors.html
-                    try:
-                        for priced in priced_objects.filter(**extra_filter):
-                            for field, value in update.items():
-                                setattr(priced, field, value)
+                    for priced in priced_objects.filter(**extra_filter):
+                        for field, value in update.items():
+                            setattr(priced, field, value)
+                        try:
                             priced.save()
-                    except Warning:
-                        pass
+                        except Warning:
+                            pass
                 except Warning:
                     pass
 

--- a/cartridge/shop/tests.py
+++ b/cartridge/shop/tests.py
@@ -12,6 +12,7 @@ from mezzanine.utils.tests import run_pep8_for_package
 
 from cartridge.shop.models import Product, ProductOption, ProductVariation
 from cartridge.shop.models import Category, Cart, Order, DiscountCode
+from cartridge.shop.models import Sale
 from cartridge.shop.checkout import CHECKOUT_STEPS
 
 
@@ -346,3 +347,55 @@ class ShopTests(TestCase):
         warnings.extend(run_pep8_for_package("cartridge"))
         if warnings:
             self.fail("Syntax warnings!\n\n%s" % "\n".join(warnings))
+
+
+class SaleTests(TestCase):
+
+    def setUp(self):
+        product1 = Product(unit_price="1.27")
+        product1.save()
+
+        ProductVariation(unit_price="1.27", product_id=product1.id).save()
+        ProductVariation(unit_price="1.27", product_id=product1.id).save()
+
+        product2 = Product(unit_price="1.27")
+        product2.save()
+
+        ProductVariation(unit_price="1.27", product_id=product2.id).save()
+        ProductVariation(unit_price="1.27", product_id=product2.id).save()
+
+        sale = Sale(
+            title="30% OFF - Ken Bruce has gone mad!",
+            discount_percent="30"
+            )
+        sale.save()
+
+        sale.products.add(product1)
+        sale.products.add(product2)
+        sale.save()
+
+    def test_sale_save(self):
+        """
+        Regression test for GitHub issue #24. Incorrect exception handle meant
+        that in some cases (usually percentage discount) sale_prices were not
+        being applied to all products and their varitations.
+
+        Note: This issues was only relevant using MySQL and with exceptions
+        turned on (which is the default when DEBUG=True).
+        """
+        # Initially no sale prices will be set.
+        for product in Product.objects.all():
+            self.assertFalse(product.sale_price)
+        for variation in ProductVariation.objects.all():
+            self.assertFalse(variation.sale_price)
+
+        # Activate the sale and verify the prices.
+        sale = Sale.objects.all()[0]
+        sale.active = True
+        sale.save()
+
+        # Afterward ensure that all the sale prices have been updated.
+        for product in Product.objects.all():
+            self.assertTrue(product.sale_price)
+        for variation in ProductVariation.objects.all():
+            self.assertTrue(variation.sale_price)


### PR DESCRIPTION
Stephen,

As it turns out this issue was only relevant when using MySQL with DEBUG=True. The DEBUG=True is important to replicate the problem because without it Warning exceptions will not be thrown, rather they will just be logged.

Interestingly I was unaware of the DEBUG element to this problem until I tried to port my test to a 'vanilla' cartridge checkout (where I had DEBUG=False). It took me some time to work out why I couldn't replicate the buggy behaviour I expected!

Cheers,
Damian
