### PR TITLE
Potential bug with sale being applied to the wrong products if the sale includes a category which contains no products

### DIFF
--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -79,19 +79,15 @@ class Category(Page, RichText):
             filters.append(reduce(iand, prices))
         # Turn the variation filters into a product filter.
         operator = iand if self.combined else ior
-        products = Q(id__in=self.products.only("id"))
-        if filters:
-            filters = reduce(operator, filters)
-            variations = ProductVariation.objects.filter(filters)
-            filters = [Q(variations__in=variations)]
-            # If filters exist, checking that products have been
-            # selected is neccessary as combining the variations
-            # with an empty ID list lookup and ``AND`` will always
-            # result in an empty result.
-            if self.products.count() > 0:
-                filters.append(products)
-            return reduce(operator, filters)
-        return products
+        category_products = self.products.only("id")
+        if category_products:
+            if filters:
+                filters = reduce(operator, filters)
+                variations = ProductVariation.objects.filter(filters)
+                filters = [Q(variations__in=variations)]
+                filters.append(Q(id__in=category_products))
+                return reduce(operator, filters)
+        return Q(id__in=category_products)
 
 
 class Priced(models.Model):


### PR DESCRIPTION
As per our discussion (see below) earlier today on freenode, here is a proposed change for what I think is a bug in the Category.filters() method:

```
11:45 <eedeep> hi there....you about? i'm working on a production cartridge site and my feeling is that I've found a bug that revolves around this: https://github.com/stephenmcd/cartridge/blob/master/cartridge/shop/models.py#L87
11:46 <stephenmcd> kinda here
11:48 <eedeep> what is happening is that a sale has a category which contains no products....because of that that if statement never evaluates to True and so what eventually happens is that all the products for the *variations* on the category are returned but not restricted by product at all
11:49 <stephenmcd> so this line https://github.com/stephenmcd/cartridge/blob/master/cartridge/shop/models.py#L82
11:49 <eedeep> so like products which have the same variations as the category restrictions get returned but they're from a whole range of categories for which we don't want the sale to apply to
11:49 <stephenmcd> should eval the list of IDS
11:49 <stephenmcd> and bail out if there are none?
11:50  * eedeep looks
11:50 <eedeep> yeah that's kind of what I was thinking
11:50 <stephenmcd> I haven't looked at the code for a while but if you can work out what needs to happen and create a pull request I'll look at it as soon as I have some time
11:51 <eedeep> I wanted to query you though because the comment here https://github.com/stephenmcd/cartridge/blob/master/cartridge/shop/models.py#L87 indicates an awareness of this scenario ....but it does still seem to result in a bug
11:51 <eedeep> yep no worries will do thanks for the feedback
11:52 <stephenmcd> sorry I just need to get my head around how it works again
11:52 <stephenmcd> will need some free time to look properly
11:52 <stephenmcd> but if you can prepare the fix and description of the problem it'll help
11:52 <stephenmcd> thanks man
11:52 <eedeep> yep I'll do the pull request...thanks for helpin
11:52 <stephenmcd> anytime
```
