### PR TITLE
Variationproxymodels

### DIFF
--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -294,8 +294,6 @@ class ProductVariationMetaclass(ModelBase):
     ``SHOP_PRODUCT_OPTIONS`` setting.
     """
     def __new__(cls, name, bases, attrs):
-        for option in settings.SHOP_OPTION_TYPE_CHOICES:
-            attrs["option%s" % option[0]] = fields.OptionField(option[1])
         #only assign new attrs if not proxy model
         if not ("Meta" in attrs and getattr(attrs["Meta"], "proxy", False)): 
             for option in settings.SHOP_OPTION_TYPE_CHOICES:


### PR DESCRIPTION
Greetings,

Here's that fix for creating a proxy model for ProductVariation
where django throws an error when ProductVariationMetaClass is adding
option%i fields.

The patch makes the meta class ignore proxy models. The
benefit is it allows proxy models for ProductVariation. 

I forgot about it until i saw the 0.5 release notes.

Regards,
Luke
