### PR TITLE
Update url templatetags for Django 1.5.

### DIFF
--- a/cartridge/shop/templates/accounts/account_profile_update.html
+++ b/cartridge/shop/templates/accounts/account_profile_update.html
@@ -2,5 +2,5 @@
 {% load i18n %}
 {% block main %}
 {{ block.super }}
-<a class="btn btn-large btn-order-history" href="{% url shop_order_history %}">{% trans "View past orders" %}</a>
+<a class="btn btn-large btn-order-history" href="{% url "shop_order_history" %}">{% trans "View past orders" %}</a>
 {% endblock %}

--- a/cartridge/shop/templates/admin/shop/order/change_form.html
+++ b/cartridge/shop/templates/admin/shop/order/change_form.html
@@ -5,7 +5,7 @@
 {% block object-tools %}
 {% if change %}{% if not is_popup %}
 <ul class="object-tools">
-<li><a href="{% url shop_invoice object_id %}?format=pdf">{% trans "Download PDF invoice" %}</a></li>
+<li><a href="{% url "shop_invoice" object_id %}?format=pdf">{% trans "Download PDF invoice" %}</a></li>
 <li><a href="history/" class="historylink">{% trans "History" %}</a></li>
 </ul>
 {% endif %}{% endif %}

--- a/cartridge/shop/templates/includes/user_panel.html
+++ b/cartridge/shop/templates/includes/user_panel.html
@@ -1,16 +1,16 @@
 {% load i18n shop_tags mezzanine_tags %}
 <div class="panel">
     {% spaceless %}
-    <a href="{% url shop_cart %}">
+    <a href="{% url "shop_cart" %}">
     {% blocktrans count request.cart.total_quantity as cart_quantity %}1 item{% plural %}{{ cart_quantity }} items{% endblocktrans %}
     {% trans "in cart" %}:
     {{ request.cart.total_price|currency }}</a><br>
     {% if request.cart.total_quantity != 0 %}
-    <a href="{% url shop_checkout %}" class="btn btn-primary">
+    <a href="{% url "shop_checkout" %}" class="btn btn-primary">
         {% trans "Go to Checkout" %}
     </a><br>
     {% endif %}
-    <a href="{% url shop_wishlist %}" class="btn-wishlist">
+    <a href="{% url "shop_wishlist" %}" class="btn-wishlist">
     {% blocktrans count request.wishlist|length as wishlist_count %}Wishlist contains 1 item{% plural %} Wishlist contains {{ wishlist_count }} items{% endblocktrans %}</a>
     {% ifinstalled mezzanine.accounts %}
     <br>

--- a/cartridge/shop/templates/shop/billing_shipping.html
+++ b/cartridge/shop/templates/shop/billing_shipping.html
@@ -11,8 +11,8 @@
 {% if not request.user.is_authenticated %}
 {% ifinstalled mezzanine.accounts %}
 <p>
-{% url login as login_url %}
-{% url signup as signup_url %}
+{% url "login" as login_url %}
+{% url "signup" as signup_url %}
 {% with request.path as next %}
 {% blocktrans %}
 If you have an existing account or would like to create one, please

--- a/cartridge/shop/templates/shop/cart.html
+++ b/cartridge/shop/templates/shop/cart.html
@@ -53,7 +53,7 @@
 </table>
 <div class="form-actions clearfix">
     <div class="form-actions-wrap">
-    <a href="{% url shop_checkout %}" class="btn btn-primary btn-large">{% trans "Go to Checkout" %}</a>
+    <a href="{% url "shop_checkout" %}" class="btn btn-primary btn-large">{% trans "Go to Checkout" %}</a>
     <input type="submit" name="update_cart" class="btn btn-large" value="{% trans "Update Cart" %}">
     </div>
 </div>

--- a/cartridge/shop/templates/shop/checkout.html
+++ b/cartridge/shop/templates/shop/checkout.html
@@ -43,7 +43,7 @@ $(function() {$('.middle :input:visible:enabled:first').focus();});
 </ul>
 {% order_totals %}
 <br style="clear:both;">
-<a class="btn" href="{% url shop_cart %}">{% trans "Edit Cart" %}</a>
+<a class="btn" href="{% url "shop_cart" %}">{% trans "Edit Cart" %}</a>
 </div>
 {% endif %}
 
@@ -78,7 +78,7 @@ $(function() {$('.middle :input:visible:enabled:first').focus();});
     <p>{% trans "This may be due to your session timing out after a period of inactivity." %}</p>
     <p>{% trans "We apologize for the inconvenience." %}</p>
     <br>
-    <p><a class="btn btn-large btn-primary" href="{% url page "shop" %}">{% trans "Continue Shopping" %}</a></p>
+    <p><a class="btn btn-large btn-primary" href="{% url "page" "shop" %}">{% trans "Continue Shopping" %}</a></p>
 	{% endif %}
 
 </form>

--- a/cartridge/shop/templates/shop/complete.html
+++ b/cartridge/shop/templates/shop/complete.html
@@ -77,8 +77,8 @@ _gaq.push(['_trackTrans']);
 <p>{% trans "You can also view your invoice using one of the links below." %}</p>
 <br>
 <p>
-    <a class="btn btn-large btn-primary" href="{% url shop_invoice order.id %}?format=pdf">{% trans "Download PDF invoice" %}</a>
-    <a class="btn btn-large" target="_blank" href="{% url shop_invoice order.id %}">{% trans "View invoice in your browser" %}</a>
+    <a class="btn btn-large btn-primary" href="{% url "shop_invoice" order.id %}?format=pdf">{% trans "Download PDF invoice" %}</a>
+    <a class="btn btn-large" target="_blank" href="{% url "shop_invoice" order.id %}">{% trans "View invoice in your browser" %}</a>
 </p>
 {% endblock %}
 

--- a/cartridge/shop/templates/shop/order_history.html
+++ b/cartridge/shop/templates/shop/order_history.html
@@ -29,8 +29,8 @@
         <td class="right">{{ order.total|currency }}</td>
         <td>{{ order.get_status_display }}</td>
         <td>
-            <a class="btn btn-small btn-primary" href="{% url shop_invoice order.id %}?format=pdf">{% trans "Download PDF" %}</a>
-            <a class="btn btn-small" target="_blank" href="{% url shop_invoice order.id %}">{% trans "View invoice" %}</a>
+            <a class="btn btn-small btn-primary" href="{% url "shop_invoice" order.id %}?format=pdf">{% trans "Download PDF" %}</a>
+            <a class="btn btn-small" target="_blank" href="{% url "shop_invoice" order.id %}">{% trans "View invoice" %}</a>
         </td>
     </tr>
     {% endfor %}

--- a/cartridge/shop/templates/shop/wishlist.html
+++ b/cartridge/shop/templates/shop/wishlist.html
@@ -37,6 +37,6 @@
 {% else %}
 <p>{% trans "Your wishlist is empty." %}</p>
 <br>
-<p><a class="btn btn-large btn-primary" href="{% url page "shop" %}">{% trans "Continue Shopping" %}</a></p>
+<p><a class="btn btn-large btn-primary" href="{% url "page" "shop" %}">{% trans "Continue Shopping" %}</a></p>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
See https://docs.djangoproject.com/en/1.4/releases/1.3/#changes-to-url-and-ssi

`{% load url from future %}` is omitted in favour of a global import in mezzanine's `boot/__init__.py`.
