### PR TITLE
fix for cartridge orders

### DIFF
--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -423,7 +423,8 @@ class Order(models.Model):
 
     # These are fields that are stored in the session. They're copied to
     # the order in setup() and removed from the session in complete().
-    session_fields = ("shipping_type", "shipping_total", "discount_total", "discount_code")
+    session_fields = ("shipping_type", "shipping_total", "discount_total",
+                      "discount_code")
 
     class Meta:
         verbose_name = _("Order")


### PR DESCRIPTION
Hi Devo,

I've noticed that when an Order goes through after a DiscountCode has been used, the discount total is stored on the Order but not the discount code (which is also stored in the session).

Here's a fix that appears to fix the problem if you're interested.

Regards,
Luke
