### PR TITLE
Catch a missing key error.

### DIFF
--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -472,7 +472,10 @@ class Order(models.Model):
         for field in self.session_fields:
             if field in request.session:
                 del request.session[field]
-        del request.session["order"]
+        try:
+            del request.session["order"]
+        except KeyError:
+            pass
         for item in request.cart:
             try:
                 variation = ProductVariation.objects.get(sku=item.sku)


### PR DESCRIPTION
Since you can't guarantee that every session has the `order` key in it,
put a try/except around the deletion.
