### PR TITLE
Fix to handle GBP (£) on Windows

### DIFF
--- a/cartridge/shop/templatetags/shop_tags.py
+++ b/cartridge/shop/templatetags/shop_tags.py
@@ -20,7 +20,8 @@ def currency(value):
         value = 0
     if hasattr(locale, "currency"):
         if platform.system() == 'Windows':
-            value = unicode(locale.currency(value, grouping=True), encoding='iso_8859_1')
+            value = unicode(locale.currency(value, grouping=True),
+                            encoding='iso_8859_1')
         else:
             value = locale.currency(value, grouping=True)
     else:


### PR DESCRIPTION
...ed hex string \xa3 for the currency symbol. Added a platform check and if Windows convert the string to unicode using iso_8859_1 encoding.
