### PR TITLE
Try except around request.cart.delete() on Order.complete()

### DIFF
--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -488,7 +488,10 @@ class Order(models.Model):
         if code:
             DiscountCode.objects.active().filter(code=code).update(
                 uses_remaining=F('uses_remaining') - 1)
-        request.cart.delete()
+        try:
+            request.cart.delete()
+        except:
+            pass
 
     def details_as_dict(self):
         """


### PR DESCRIPTION
I'm not exactly sure how this happens but it isn't the first time. Just got: "AttributeError: 'EmptyCart' object has no attribute 'delete' when a user was completing an order. The cart is already empty once the user reaches this point. 

My guess is the buyer completes an order, presses back which gets the success url we send to Paypal for the redirect back from Paypal after a buyer pays. The cart would have already been deleted at that point.  Thats my best guess at 2:30am, and waking up to fix this. 
