### PR TITLE
Allow for open ended sales, only requiring start date

### DIFF
--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -54,8 +54,8 @@ class Priced(models.Model):
         Returns True if the sale price is applicable.
         """
         n = now()
-        valid_from = self.sale_from is not None and self.sale_from < n
-        valid_to = self.sale_to is not None and self.sale_to > n
+        valid_from = self.sale_from is not None and self.sale_from <= n
+        valid_to = self.sale_to is None or self.sale_to >= n
         return self.sale_price is not None and valid_from and valid_to
 
     def has_price(self):


### PR DESCRIPTION
Stephen,

With this suggested code change, I am trying to support the following template code:

```
{% if not p.on_sale %}
    {{ p.price|currency }}
{% else %}
    <del>{{ p.unit_price|currency }}</del>
    {{ p.sale_price|currency }}<br>
    <span class="label label-success">Save {{ p.unit_price|subtract:p.price|currency }}</span>
{% endif %}
```

Perhaps there is another way to accomplish this, but being able to check if p.on_sale allows for setting prices for when the sale is effective and design the template code that will highlight the sale price if the sale is in effect rather than simply if there is a configured sale price. I think this change supports your desire to be able to configure a sale without an end date. No idea if the logic in the admin allows for setting a start date without an end date yet.

Thoughts? (this is yet untested but passes my visual parser)
