### PR TITLE
Fix AttributeError with empty cart in Django 1.5

### DIFF
--- a/cartridge/shop/utils.py
+++ b/cartridge/shop/utils.py
@@ -1,4 +1,3 @@
-
 import hmac
 from locale import setlocale, LC_MONETARY
 try:
@@ -21,6 +20,7 @@ class EmptyCart(object):
     """
 
     id = None
+    pk = None
     has_items = lambda *a, **k: False
     skus = lambda *a, **k: []
     upsell_products = lambda *a, **k: []


### PR DESCRIPTION
With a default Mezzanine/Cartridge installation under Django 1.5 I was getting an AttributeError requesting /shop/cart/ with an empty cart.

Django 1.5's BaseInlineFormSet.**init** looks for a pk on the form instance, which it couldn't find on EmptyCart.

The one-line fix adds the pk attribute with value None.
