### PR TITLE
Fix admin menu not translating to English when it's not the default language

### DIFF
--- a/cartridge/shop/defaults.py
+++ b/cartridge/shop/defaults.py
@@ -1,7 +1,7 @@
 
 from socket import gethostname
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from mezzanine.conf import register_setting
 


### PR DESCRIPTION
If you have English defined as a second language and browse to `en/admin` the top menu will still display translations from the default language.

Here's a [diff from a fresh Cartridge setup](https://gist.github.com/4702111) with changes needed to reproduce the problem (note the languages order).
