### PR TITLE
AddProductForm without any option types

### DIFF
--- a/cartridge/shop/forms.py
+++ b/cartridge/shop/forms.py
@@ -66,8 +66,11 @@ class AddProductForm(forms.Form):
         # Adding from the product page, remove the sku field
         # and build the choice fields for the variations.
         del self.fields["sku"]
+        option_fields = ProductVariation.option_fields()
+        if not option_fields:
+            return
         option_names, option_labels = zip(*[(f.name, f.verbose_name)
-            for f in ProductVariation.option_fields()])
+            for f in option_fields])
         option_values = zip(*self._product.variations.filter(
             unit_price__isnull=False).values_list(*option_names))
         if option_values:


### PR DESCRIPTION
If you disable variations completely (creating database without any option columns):

``` python
SHOP_USE_VARIATIONS = False
SHOP_OPTION_TYPE_CHOICES = tuple()
```

and browse to a product page a `ValueError` ("need more than 0 values to unpack") exception is thrown.
