### PR TITLE
Fields_for hidden_fields

### DIFF
--- a/cartridge/shop/forms.py
+++ b/cartridge/shop/forms.py
@@ -207,6 +207,9 @@ class FormsetForm(object):
         filters = (
             ("^other_fields$", lambda:
                 self.fields.keys()),
+            ("^hidden_fields$", lambda:
+                [n for n, f in self.fields.iteritems()
+                 if isinstance(f.widget, forms.HiddenInput)]),
             ("^(\w*)_fields$", lambda name:
                 [f for f in self.fields.keys() if f.startswith(name)]),
             ("^(\w*)_field$", lambda name:


### PR DESCRIPTION
One more option for the `fields_for` tag -- `hidden_fields`. Useful when you need to display some fields directly, but would like to auto-include fields hidden for other checkout steps (`other_fields` would double fields for which the tag is not used).
