### PR TITLE
Add SHOP_USE_RATINGS (default True), allowing ratings to be disabled.

### DIFF
--- a/cartridge/shop/defaults.py
+++ b/cartridge/shop/defaults.py
@@ -59,7 +59,7 @@ register_setting(
     editable=False,
     default=("SHOP_CARD_TYPES", "SHOP_CATEGORY_USE_FEATURED_IMAGE",
              "SHOP_CHECKOUT_STEPS_SPLIT", "SHOP_PAYMENT_STEP_ENABLED",
-             "SHOP_PRODUCT_SORT_OPTIONS",),
+             "SHOP_PRODUCT_SORT_OPTIONS", "SHOP_USE_RATINGS"),
     append=True,
 )
 
@@ -272,6 +272,14 @@ register_setting(
     name="SHOP_USE_VARIATIONS",
     label=_("Use product variations"),
     description="Use product variations.",
+    editable=False,
+    default=True,
+)
+
+register_setting(
+    name="SHOP_USE_RATINGS",
+    label=_("Use product ratings"),
+    description="Show the product rating form, and allow browsing by rating.",
     editable=False,
     default=True,
 )

--- a/cartridge/shop/templates/pages/category.html
+++ b/cartridge/shop/templates/pages/category.html
@@ -38,10 +38,12 @@
     <label>{% trans "Sort by" %}</label>
     <select onchange="location.href = this[this.selectedIndex].value;">
     {% for name, option in settings.SHOP_PRODUCT_SORT_OPTIONS %}
+    {% if "rating" not in option or settings.SHOP_USE_RATINGS %}
     <option{% if option == products.sort_by %} selected{% endif %}
         value="{{ category.get_absolute_url }}?sort={{ option }}{{ querystring }}">
         {{ name }}
     </option>
+    {% endif %}
     {% endfor %}
     </select>
 </form>

--- a/cartridge/shop/templates/shop/product.html
+++ b/cartridge/shop/templates/shop/product.html
@@ -100,7 +100,9 @@
 <p>{% trans "This product is currently unavailable." %}</p>
 {% endif %}
 
+{% if settings.SHOP_USE_RATINGS %}
 {% rating_for product %}
+{% endif %}
 
 {% if related_products %}
 <h2>{% trans "Related Products" %}</h2>


### PR DESCRIPTION
Motivated by a small store, for which ratings are irrelevant (you're either buying the sole product or you aren't :)

The conditional in `category.html` might be better done as a context processor-supplied filtered view of `SHOP_PRODUCT_SORT_OPTIONS`, but I didn't see one to piggyback on.  Since this the only template that uses it, my first approach is the lazy one; let me know if you prefer something else..
