### PR TITLE
Add setting SHOP_ORDER_EMAIL_BCC

### DIFF
--- a/cartridge/shop/checkout.py
+++ b/cartridge/shop/checkout.py
@@ -173,9 +173,10 @@ def send_order_email(request, order):
         warn("Shop email receipt templates have moved from "
              "templates/shop/email/ to templates/email/")
     send_mail_template(settings.SHOP_ORDER_EMAIL_SUBJECT,
-        receipt_template, settings.SHOP_ORDER_FROM_EMAIL,
-        order.billing_detail_email, context=order_context,
-        fail_silently=settings.DEBUG)
+                       receipt_template, settings.SHOP_ORDER_FROM_EMAIL,
+                       order.billing_detail_email, context=order_context,
+                       fail_silently=settings.DEBUG,
+                       addr_bcc=settings.SHOP_ORDER_EMAIL_BCC or None)
 
 
 # Set up some constants for identifying each checkout step.

--- a/cartridge/shop/defaults.py
+++ b/cartridge/shop/defaults.py
@@ -239,6 +239,14 @@ register_setting(
 )
 
 register_setting(
+    name="SHOP_ORDER_EMAIL_BCC",
+    label=_("BCC receipts to"),
+    description=_("All order receipts will be BCCd to this address."),
+    editable=True,
+    default="",
+)
+
+register_setting(
     name="SHOP_ORDER_STATUS_CHOICES",
     description="Sequence of value/name pairs for order statuses.",
     editable=False,


### PR DESCRIPTION
If used, this should be set to an internal email address. All order receipt emails will be sent to this address via BCC, as well as being sent to the customer.

Requires https://github.com/stephenmcd/mezzanine/pull/663.
