### PR TITLE
Send email notification to manager when order come

### DIFF
--- a/cartridge/shop/checkout.py
+++ b/cartridge/shop/checkout.py
@@ -177,6 +177,10 @@ def send_order_email(request, order):
                        order.billing_detail_email, context=order_context,
                        fail_silently=settings.DEBUG,
                        addr_bcc=settings.SHOP_ORDER_EMAIL_BCC or None)
+    send_mail_template(settings.SHOP_ORDER_EMAIL_SUBJECT,
+                       receipt_template, settings.SHOP_ORDER_FROM_EMAIL,
+                       settings.SHOP_ORDER_FROM_EMAIL, context=order_context,
+                       fail_silently=settings.DEBUG)
 
 
 # Set up some constants for identifying each checkout step.


### PR DESCRIPTION
In my case of using cartridge manager want to have notification about new orders. In this pull request I add email notification. This is not perfect solution, but it works for me fine for now.

So, maybe add notification callback here - to let developer add his own notification code (SMS for example)?
