### PR TITLE
Revert cart to old values if update is not valid

### DIFF
--- a/cartridge/shop/views.py
+++ b/cartridge/shop/views.py
@@ -153,6 +153,8 @@ def cart(request, template="shop/cart.html"):
                     cart_formset.save()
                     recalculate_discount(request)
                     info(request, _("Cart updated"))
+                else:
+                    cart_formset = CartItemFormSet(instance=request.cart)
         else:
             valid = discount_form.is_valid()
             if valid:


### PR DESCRIPTION
In the current implementation, when you update the cart, and the form is not valid (because the amount specified is not available, etc.), the cart is rendered with the values input by user. This is a bit confusing sometimes because user sees a error message, but the cart still seems to have updated on screen. I add a clause to revert the cart formset to old values if the user input is not successful, so that the user always sees the "correct" values on screen.
