### PR TITLE
Fix UnicodeEncodeError in ProductVariation.__unicode__

### DIFF
--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -234,7 +234,8 @@ class ProductVariation(Priced):
                     verbose_name = verbose_name.decode("utf-8")
                 option = u"%s: %s" % (verbose_name, name)
                 options.append(option)
-        return ("%s %s" % (unicode(self.product), ", ".join(options))).strip()
+        result = u"%s %s" % (unicode(self.product), u", ".join(options))
+        return result.strip()
 
     def save(self, *args, **kwargs):
         """


### PR DESCRIPTION
field.verbose_name.decode(utf-8) raises UnicodeError if verbose_name can
not be encoded by ASCII.

This error occurs when you apply a translation to field.verbose_name and try to access the product admin. As the translation is (usually) not encodable by ASCII, a UnicodeEncodeError ('ascii' codec can't encode characters in position 0-1: ordinal not in range(128)) is raised.
