### PR TITLE
New setting SHOP_SHOW_SIGNUPLOGIN to hide signup/login links inside shop

### DIFF
--- a/cartridge/shop/defaults.py
+++ b/cartridge/shop/defaults.py
@@ -301,3 +301,13 @@ register_setting(
     editable=False,
     default=True,
 )
+
+register_setting(
+    name="SHOP_SHOW_SIGNUPLOGIN",
+    label=_("Show sign up and log in links"),
+    description="Show the links to sign up or log in. "
+        "Only affects the visibility of the links, not ability to sign up "
+        "or log in.",
+    editable=False,
+    default=True,
+)

--- a/cartridge/shop/templates/includes/user_panel.html
+++ b/cartridge/shop/templates/includes/user_panel.html
@@ -14,9 +14,11 @@
     <a href="{% url "shop_wishlist" %}" class="btn-wishlist">
     {% blocktrans count request.wishlist|length as wishlist_count %}Wishlist contains 1 item{% plural %} Wishlist contains {{ wishlist_count }} items{% endblocktrans %}</a>
     {% endif %}
+    {% if settings.SHOP_SHOW_SIGNUPLOGIN %}
     {% ifinstalled mezzanine.accounts %}
     <br>
     {% include "accounts/includes/user_panel.html" %}
     {% endifinstalled %}
+    {% endif %}
     {% endspaceless %}
 </div>

--- a/cartridge/shop/templates/shop/billing_shipping.html
+++ b/cartridge/shop/templates/shop/billing_shipping.html
@@ -8,6 +8,7 @@
 
 {% block fields %}
 {% if request.cart.has_items %}
+{% if settings.SHOP_SHOW_SIGNUPLOGIN %}
 {% if not request.user.is_authenticated %}
 {% ifinstalled mezzanine.accounts %}
 <p>
@@ -22,6 +23,7 @@ If you have an existing account or would like to create one, please
 {% endwith %}
 </p>
 {% endifinstalled %}
+{% endif %}
 {% endif %}
 
 <fieldset>


### PR DESCRIPTION
A new setting to hide signup / login links in the user panel which by default are shown there. In some shops there is no possibility for users to create accounts and thus this use case was needed in my project, hoping to be able to transfer it upstream.
