### PR TITLE
New setting SHOP_HIDE_BILLING_SHIPPING_FIELDS

### DIFF
--- a/cartridge/shop/defaults.py
+++ b/cartridge/shop/defaults.py
@@ -301,3 +301,10 @@ register_setting(
     editable=False,
     default=True,
 )
+
+register_setting(
+    name="SHOP_HIDE_BILLING_SHIPPING_FIELDS",
+    description=_("Sequence of columns to hide in billing and shipping."),
+    editable=False,
+    default=(),
+)

--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -391,21 +391,30 @@ class Order(models.Model):
 
     billing_detail_first_name = CharField(_("First name"), max_length=100)
     billing_detail_last_name = CharField(_("Last name"), max_length=100)
-    billing_detail_street = CharField(_("Street"), max_length=100)
-    billing_detail_city = CharField(_("City/Suburb"), max_length=100)
-    billing_detail_state = CharField(_("State/Region"), max_length=100)
-    billing_detail_postcode = CharField(_("Zip/Postcode"), max_length=10)
-    billing_detail_country = CharField(_("Country"), max_length=100)
-    billing_detail_phone = CharField(_("Phone"), max_length=20)
+    billing_detail_street = CharField(_("Street"), max_length=100, blank=True)
+    billing_detail_city = CharField(_("City/Suburb"), max_length=100,
+                                    blank=True)
+    billing_detail_state = CharField(_("State/Region"), max_length=100,
+                                     blank=True)
+    billing_detail_postcode = CharField(_("Zip/Postcode"), max_length=10,
+                                        blank=True)
+    billing_detail_country = CharField(_("Country"), max_length=100,
+                                       blank=True)
+    billing_detail_phone = CharField(_("Phone"), max_length=20, blank=True)
     billing_detail_email = models.EmailField(_("Email"))
     shipping_detail_first_name = CharField(_("First name"), max_length=100)
     shipping_detail_last_name = CharField(_("Last name"), max_length=100)
-    shipping_detail_street = CharField(_("Street"), max_length=100)
-    shipping_detail_city = CharField(_("City/Suburb"), max_length=100)
-    shipping_detail_state = CharField(_("State/Region"), max_length=100)
-    shipping_detail_postcode = CharField(_("Zip/Postcode"), max_length=10)
-    shipping_detail_country = CharField(_("Country"), max_length=100)
-    shipping_detail_phone = CharField(_("Phone"), max_length=20)
+    shipping_detail_street = CharField(_("Street"), max_length=100,
+                                       blank=True)
+    shipping_detail_city = CharField(_("City/Suburb"), max_length=100,
+                                     blank=True)
+    shipping_detail_state = CharField(_("State/Region"), max_length=100,
+                                      blank=True)
+    shipping_detail_postcode = CharField(_("Zip/Postcode"), max_length=10,
+                                         blank=True)
+    shipping_detail_country = CharField(_("Country"), max_length=100,
+                                        blank=True)
+    shipping_detail_phone = CharField(_("Phone"), max_length=20, blank=True)
     additional_instructions = models.TextField(_("Additional instructions"),
                                                blank=True)
     time = models.DateTimeField(_("Time"), auto_now_add=True, null=True)


### PR DESCRIPTION
Some shops do not necessarily need to ship anything - so address fields can be totally unnecessary bloat on the form. For example virtual or digital products. This setting allows to hide some fields from the form. In this case they will be stored in the database as empty (not null).

An example of this setting would be to hide address fields (a real use case in a production site I am running):
SHOP_HIDE_BILLING_SHIPPING_FIELDS = ( "street",
    "city", "state", "postcode", "country",  
)

Validation has been changed to allow for this.
