### PR TITLE
On last step of checkout, show Complete instead of Next

### DIFF
--- a/cartridge/shop/templates/shop/checkout.html
+++ b/cartridge/shop/templates/shop/checkout.html
@@ -70,7 +70,11 @@ $(function() {$('.middle :input:visible:enabled:first').focus();});
 		{% if request.cart.has_items %}
 			<div class="form-actions clearfix">
 				<div class="form-actions-wrap">
-				<input type="submit" class="btn btn-large btn-primary" value="{% trans "Next" %}">
+				{% if step == steps|length %}
+					<input type="submit" class="btn btn-large btn-primary" value="{% trans "Complete" %}">
+				{% else %}
+					<input type="submit" class="btn btn-large btn-primary" value="{% trans "Next" %}">
+				{% endif %}
 				{% if not CHECKOUT_STEP_FIRST %}
 				<input type="submit" class="btn btn-large" name="back" value="{% trans "Back" %}">
 				{% endif %}


### PR DESCRIPTION
If we are on the last checkout step, show 'Complete' instead of 'Next'.
