### PR TITLE
New settings SHOP_TOS_ON_CHECKOUT and SHOP_TOS_URL

### DIFF
--- a/cartridge/shop/defaults.py
+++ b/cartridge/shop/defaults.py
@@ -301,3 +301,19 @@ register_setting(
     editable=False,
     default=True,
 )
+
+register_setting(
+    name="SHOP_TOS_ON_CHECKOUT",
+    label=_("Show Terms of Service link on checkout."),
+    description="Show Terms of Service url and warning on last checkout page.",
+    editable=True,
+    default=False,
+)
+
+register_setting(
+    name="SHOP_TOS_URL",
+    label=_("Terms of Service url"),
+    description="Shown on last checkout page if SHOP_TOS_ON_CHECKOUT is enabled",
+    editable=True,
+    default="",
+)

--- a/cartridge/shop/templates/shop/checkout.html
+++ b/cartridge/shop/templates/shop/checkout.html
@@ -68,6 +68,14 @@ $(function() {$('.middle :input:visible:enabled:first').focus();});
 	
 	{% block nav-buttons %}
 		{% if request.cart.has_items %}
+			{% if tos_url and step == steps|length %}
+				<div class="span7">
+					{% blocktrans %}
+					By continuing you accept the
+					<a href="{{ tos_url }}" target="_blanc">Terms of Service</a>.
+					{% endblocktrans %}
+				</div>
+			{% endif %}
 			<div class="form-actions clearfix">
 				<div class="form-actions-wrap">
 				<input type="submit" class="btn btn-large btn-primary" value="{% trans "Next" %}">

--- a/cartridge/shop/views.py
+++ b/cartridge/shop/views.py
@@ -294,6 +294,10 @@ def checkout_steps(request):
     context = {"form": form, "CHECKOUT_STEP_FIRST": CHECKOUT_STEP_FIRST,
                "step_title": step_vars["title"], "step_url": step_vars["url"],
                "steps": checkout.CHECKOUT_STEPS, "step": step}
+    if settings.SHOP_TOS_ON_CHECKOUT and step == len(checkout.CHECKOUT_STEPS):
+        context['tos_url'] = settings.SHOP_TOS_URL
+    else:
+        context['tos_url'] = False
     return render(request, template, context)
 
 


### PR DESCRIPTION
Sometimes, when selling digital services for example, a terms of service should be accepted when completing checkout. Provide URL on last checkout page via settings, text saying "By continuing you accept the Terms of Service".
