### PR TITLE
using already applied discount code (from session) to determine the _dis...

### DIFF
--- a/cartridge/shop/forms.py
+++ b/cartridge/shop/forms.py
@@ -254,8 +254,9 @@ class DiscountForm(forms.ModelForm):
         testing = getattr(settings, "TESTING", False)
         if "discount_code" in self._request.session and not testing:
             # Already applied
-            return ""
-        code = self.cleaned_data.get("discount_code", "")
+            code = self._request.session["discount_code"]
+        else:
+            code = self.cleaned_data.get("discount_code", "")
         cart = self._request.cart
         if code:
             try:


### PR DESCRIPTION
using already applied discount code (from session) to determine the _discount member of DiscountForm. Required so that when set_discount() is called from recalculate_cart(), the discount amount is recalculated based on the current cart. Fixes #132
