### PR TITLE
Allow Discount Code to reduce item amount to 0

### DIFF
--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -836,7 +836,7 @@ class DiscountCode(Discount):
         if self.discount_deduct is not None:
             # Don't apply to amounts that would be negative after
             # deduction.
-            if self.discount_deduct < amount:
+            if self.discount_deduct <= amount:
                 return self.discount_deduct
         elif self.discount_percent is not None:
             return amount / Decimal("100") * self.discount_percent


### PR DESCRIPTION
Basically replacing < with <= so that a discount code that is the same amount as an item can reduce that item's price to 0. Handy if the code is essentially a 'voucher' for a free item of that product.
