### PR TITLE
Create a setting for which template is used when rendering an invoice as a PDF.

### DIFF
--- a/cartridge/shop/defaults.py
+++ b/cartridge/shop/defaults.py
@@ -312,3 +312,11 @@ register_setting(
     editable=False,
     default=True,
 )
+
+register_setting(
+    name="SHOP_INVOICE_AS_PDF_TEMPLATE",
+    description="Relative path to the template to be used for rendering invoices "
+        " as PDFs",
+    editable=False,
+    default="shop/order_invoice.html",
+)

--- a/cartridge/shop/views.py
+++ b/cartridge/shop/views.py
@@ -354,7 +354,7 @@ def invoice(request, order_id, template="shop/order_invoice.html"):
         response = HttpResponse(mimetype="application/pdf")
         name = slugify("%s-invoice-%s" % (settings.SITE_TITLE, order.id))
         response["Content-Disposition"] = "attachment; filename=%s.pdf" % name
-        html = get_template(template).render(context)
+        html = get_template(settings.SHOP_INVOICE_AS_PDF_TEMPLATE).render(context)
         import ho.pisa
         ho.pisa.CreatePDF(html, response)
         return response


### PR DESCRIPTION
It is useful to use a different template for rendering as PDF. I've set up a site with the normal invoice template integrated into the standard site navigation, which makes the PDF version look terrible.
