### PR TITLE
Add settings to toggle related and upsell products

### DIFF
--- a/cartridge/shop/admin.py
+++ b/cartridge/shop/admin.py
@@ -122,9 +122,16 @@ product_fieldsets = deepcopy(DisplayableAdmin.fieldsets)
 product_fieldsets[0][1]["fields"].insert(2, "available")
 product_fieldsets[0][1]["fields"].extend(["content", "categories"])
 product_fieldsets = list(product_fieldsets)
-product_fieldsets.append((_("Other products"), {
-    "classes": ("collapse-closed",),
-    "fields": ("related_products", "upsell_products")}))
+
+other_product_fields = []
+if settings.SHOP_USE_RELATED_PRODUCTS:
+    other_product_fields.append("related_products")
+if settings.SHOP_USE_UPSELL_PRODUCTS:
+    other_product_fields.append("upsell_products")
+if len(other_product_fields) > 0:
+    product_fieldsets.append((_("Other products"), {
+        "classes": ("collapse-closed",),
+        "fields": tuple(other_product_fields)}))
 
 product_list_display = ["admin_thumb", "title", "status", "available",
                         "admin_link"]
@@ -152,7 +159,7 @@ class ProductAdmin(DisplayableAdmin):
     list_display_links = ("admin_thumb", "title")
     list_editable = product_list_editable
     list_filter = ("status", "available", "categories")
-    filter_horizontal = ("categories", "related_products", "upsell_products")
+    filter_horizontal = ("categories",) + tuple(other_product_fields)
     search_fields = ("title", "content", "categories__title",
                      "variations__sku")
     inlines = (ProductImageAdmin, ProductVariationAdmin)

--- a/cartridge/shop/defaults.py
+++ b/cartridge/shop/defaults.py
@@ -61,7 +61,8 @@ register_setting(
     default=("SHOP_CARD_TYPES", "SHOP_CATEGORY_USE_FEATURED_IMAGE",
              "SHOP_CHECKOUT_STEPS_SPLIT", "SHOP_PAYMENT_STEP_ENABLED",
              "SHOP_PRODUCT_SORT_OPTIONS", "SHOP_USE_RATINGS",
-             "SHOP_USE_WISHLIST"),
+             "SHOP_USE_WISHLIST", "SHOP_USE_RELATED_PRODUCTS",
+             "SHOP_USE_UPSELL_PRODUCTS"),
     append=True,
 )
 
@@ -302,6 +303,24 @@ register_setting(
     label=_("Use product wishlist"),
     description="Show the links to the wishlist, and allow adding "
         "products to it.",
+    editable=False,
+    default=True,
+)
+
+register_setting(
+    name="SHOP_USE_RELATED_PRODUCTS",
+    label=_("Use related products"),
+    description="Show related products in templates, and allow "
+        "editing them in the admin.",
+    editable=False,
+    default=True,
+)
+
+register_setting(
+    name="SHOP_USE_UPSELL_PRODUCTS",
+    label=_("Use upsell products"),
+    description="Show upsell products in templates, and allow "
+        "editing them in the admin.",
     editable=False,
     default=True,
 )

--- a/cartridge/shop/forms.py
+++ b/cartridge/shop/forms.py
@@ -485,7 +485,7 @@ class ProductAdminForm(with_metaclass(ProductAdminFormMetaclass,
         """
         Set the choices for each of the fields for product options.
         Also remove the current instance from choices for related and
-        upsell products.
+        upsell products (if enabled).
         """
         super(ProductAdminForm, self).__init__(*args, **kwargs)
         for field, options in list(ProductOption.objects.as_fields().items()):
@@ -493,8 +493,10 @@ class ProductAdminForm(with_metaclass(ProductAdminFormMetaclass,
         instance = kwargs.get("instance")
         if instance:
             queryset = Product.objects.exclude(id=instance.id)
-            self.fields["related_products"].queryset = queryset
-            self.fields["upsell_products"].queryset = queryset
+            if settings.SHOP_USE_RELATED_PRODUCTS:
+                self.fields["related_products"].queryset = queryset
+            if settings.SHOP_USE_UPSELL_PRODUCTS:
+                self.fields["upsell_products"].queryset = queryset
 
 
 class ProductVariationAdminForm(forms.ModelForm):

--- a/cartridge/shop/templates/shop/cart.html
+++ b/cartridge/shop/templates/shop/cart.html
@@ -74,6 +74,7 @@
 </form>
 {% endif %}
 
+{% if settings.SHOP_USE_UPSELL_PRODUCTS %}
 {% with request.cart.upsell_products as upsell_products %}
 {% if upsell_products %}
 <h2>{% trans "You may also like:" %}</h2>
@@ -104,6 +105,7 @@
 </div>
 {% endif %}
 {% endwith %}
+{% endif %}
 
 {% else %}
 <p>{% trans "Your Cart is empty." %}</p>

--- a/cartridge/shop/templates/shop/product.html
+++ b/cartridge/shop/templates/shop/product.html
@@ -126,7 +126,7 @@ $(document).ready(function() {
 </div>
 {% endif %}
 
-{% if related_products %}
+{% if settings.SHOP_USE_RELATED_PRODUCTS and related_products %}
 <h2>{% trans "Related Products" %}</h2>
 <div class="row related-products">
     {% for product in related_products %}


### PR DESCRIPTION
This doesn't touch the database, but merely hides the fields from admin and shop templates.

It of course defaults to on/True.

Feel free to reject if not appropriate - but it's useful for us since we have 5,000+ products and generating the admin filter lists takes a long time!
