### PR TITLE
Convert shipping_total and tax_total to strings

### DIFF
--- a/cartridge/shop/utils.py
+++ b/cartridge/shop/utils.py
@@ -110,7 +110,7 @@ def set_shipping(request, shipping_type, shipping_total):
     """
     from future.builtins import str
     request.session["shipping_type"] = str(shipping_type)
-    request.session["shipping_total"] = shipping_total
+    request.session["shipping_total"] = str(shipping_total)
 
 
 def set_tax(request, tax_type, tax_total):
@@ -119,7 +119,7 @@ def set_tax(request, tax_type, tax_total):
     """
     from future.builtins import str
     request.session["tax_type"] = str(tax_type)
-    request.session["tax_total"] = tax_total
+    request.session["tax_total"] = str(tax_total)
 
 
 def sign(value):


### PR DESCRIPTION
As of Django 1.6 Decimal's cannot be stored in sessions.  Convert shipping_total and tax_total to strings before storing in the session.
