### PR TITLE
Adding reportlab 2.7 as a dependency, with a comment that this is due to...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,12 @@ try:
         install_requires=[
             "mezzanine >= 3.0.6",
             "pisa >= 3.0.33",
+            "reportlab == 2.7"
         ],
+        # NOTE: reportlab 3.0 does not work with pisa 3.0.33, due to a
+        # bad version check. 
+        # However, reportlab 2.7 will not work with Python 3!
+        # 
 
         classifiers=[
             "Development Status :: 4 - Beta",


### PR DESCRIPTION
... a bug in pisa, and also that this may not work on Python 3.x
