### PR TITLE
Add SHOP_PER_PAGE_CATEGORY to default TEMPLATE_ACCESSIBLE_SETTINGS.

### DIFF
--- a/cartridge/shop/defaults.py
+++ b/cartridge/shop/defaults.py
@@ -62,7 +62,7 @@ register_setting(
              "SHOP_CHECKOUT_STEPS_SPLIT", "SHOP_PAYMENT_STEP_ENABLED",
              "SHOP_PRODUCT_SORT_OPTIONS", "SHOP_USE_RATINGS",
              "SHOP_USE_WISHLIST", "SHOP_USE_RELATED_PRODUCTS",
-             "SHOP_USE_UPSELL_PRODUCTS"),
+             "SHOP_USE_UPSELL_PRODUCTS", "SHOP_PER_PAGE_CATEGORY"),
     append=True,
 )
 


### PR DESCRIPTION
Super simple change to make the number of products per page accessible by default in templates. It's necessary for third-party paginators and handy for other template bits and pieces.

IMO it warrants inclusion by default, what do you think?
