### PR TITLE
More liberal handling of value in currency tag

### DIFF
--- a/cartridge/shop/templatetags/shop_tags.py
+++ b/cartridge/shop/templatetags/shop_tags.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from future.builtins import str
 
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 import locale
 import platform
 
@@ -20,10 +20,12 @@ def currency(value):
     Format a value as currency according to locale.
     """
     set_locale()
-    if not value:
-        value = 0
+    try:
+        value = Decimal(value)
+    except (InvalidOperation, TypeError):
+        value = Decimal('0.00')
     if hasattr(locale, "currency"):
-        value = locale.currency(Decimal(value), grouping=True)
+        value = locale.currency(value, grouping=True)
         if platform.system() == 'Windows':
             try:
                 value = str(value, encoding='iso_8859_1')


### PR DESCRIPTION
If the value passed to the `currency` tag can't be converted to Decimal, assume 0 instead of raising an exception.

I ran into this as a side-effect of the session serialising/deserialising changes: ended up passing `"None"` instead of `None`. I'm still trying to track down that bug in my code, but I feel the currency tag should just default to 0 in all error cases, as it does with None currently.
