### PR TITLE
Replace removed mimetype argument to HttpResponse

### DIFF
--- a/cartridge/shop/views.py
+++ b/cartridge/shop/views.py
@@ -369,7 +369,7 @@ def invoice(request, order_id, template="shop/order_invoice.html",
     context.update(order.details_as_dict())
     context = RequestContext(request, context)
     if request.GET.get("format") == "pdf":
-        response = HttpResponse(mimetype="application/pdf")
+        response = HttpResponse(content_type="application/pdf")
         name = slugify("%s-invoice-%s" % (settings.SITE_TITLE, order.id))
         response["Content-Disposition"] = "attachment; filename=%s.pdf" % name
         html = get_template(template_pdf).render(context)


### PR DESCRIPTION
The `mimetype` argument to HttpResponse has been removed in Django 1.7 after the standard deprecation cycle. `content_type` has been available as an alias from 1.4, so changing it should be fine.
