### PR TITLE
Replace Cart with self.model in CartManager

### DIFF
--- a/cartridge/shop/managers.py
+++ b/cartridge/shop/managers.py
@@ -40,8 +40,7 @@ class CartManager(Manager):
                 request.session.modified = True
             except KeyError:
                 pass
-            from cartridge.shop.models import Cart
-            cart = Cart(last_updated=now())
+            cart = self.model(last_updated=now())
         return cart
 
     def expiry_time(self):


### PR DESCRIPTION
This makes CartManager work correctly when used with a proxy of Cart.
