### PR TITLE
Attempt to fix build, closes #222

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 matrix:
   exclude:
      - python: "3.3"
-       env: DJANGO_VERSION=1.4.13
+       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.4.x.zip
 install:
   - pip install $DJANGO_VERSION --use-mirrors
   - pip install -e git://github.com/stephenmcd/mezzanine.git#egg=mezzanine


### PR DESCRIPTION
As pointed out at #222, this updates exclude build of Django 1.4 vs Python 3.3.
