### PR TITLE
Add object-tools-items block to order admin template

### DIFF
--- a/cartridge/shop/templates/admin/shop/order/change_form.html
+++ b/cartridge/shop/templates/admin/shop/order/change_form.html
@@ -7,11 +7,13 @@
     {% csrf_token %}
 </form>
 <ul class="object-tools">
+    {% block object-tools-items %}
     {% if has_pdf %}
     <li><a href="{% url "shop_invoice" object_id %}?format=pdf">{% trans "Download PDF invoice" %}</a></li>
     {% endif %}
     <li><a href="#" onclick="document.getElementById('resend-email').submit(); return false;">{% trans "Re-send order email" %}</a></li>
     <li><a href="history/" class="historylink">{% trans "History" %}</a></li>
+    {% endblock %}
 </ul>
 {% endif %}{% endif %}
 {% endblock %}


### PR DESCRIPTION
Nothing too tricky here, just adding the block.

A better change would be to stash the resend-email form in a different block (perhaps `before_content`?) from all the way up in `admin/base.html`. That way just `object-tools-items` could be extended like I did in the stephenmcd/mezzanine#1296 pull request.

That would help prevent the `object-tools` block from getting out of date, like it currently is (it's missing 'View on Site' which all other change forms have).