### PR TITLE
Better use of object-tools-items block in Order admin template

### DIFF
--- a/cartridge/shop/templates/admin/shop/order/change_form.html
+++ b/cartridge/shop/templates/admin/shop/order/change_form.html
@@ -1,19 +1,18 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
 
-{% block object-tools %}
-{% if change %}{% if not is_popup %}
-<form id="resend-email" method="POST" action="{% url "shop_invoice_resend" object_id %}?next={{ request.path }}">
-    {% csrf_token %}
-</form>
-<ul class="object-tools">
-    {% block object-tools-items %}
+{% block before_content %}
+    <form id="resend-email" method="POST" action="{% url "shop_invoice_resend" object_id %}?next={{ request.path }}">
+        {% csrf_token %}
+     </form>
+
+    {{ block.super }}
+{% endblock %}
+
+{% block object-tools-items %}
     {% if has_pdf %}
     <li><a href="{% url "shop_invoice" object_id %}?format=pdf">{% trans "Download PDF invoice" %}</a></li>
     {% endif %}
     <li><a href="#" onclick="document.getElementById('resend-email').submit(); return false;">{% trans "Re-send order email" %}</a></li>
-    <li><a href="history/" class="historylink">{% trans "History" %}</a></li>
-    {% endblock %}
-</ul>
-{% endif %}{% endif %}
+    {{ block.super }}
 {% endblock %}


### PR DESCRIPTION
Implemented what I mentioned in #243. Better use of `object-tools-items` should keep it up to date if anything changes in the base admin templates.