### PR TITLE
Drop locale.currency workaround for Python 2.4

### DIFF
--- a/cartridge/shop/templatetags/shop_tags.py
+++ b/cartridge/shop/templatetags/shop_tags.py
@@ -22,22 +22,12 @@ def currency(value):
     set_locale()
     if not value:
         value = 0
-    if hasattr(locale, "currency"):
-        value = locale.currency(Decimal(value), grouping=True)
-        if platform.system() == 'Windows':
-            try:
-                value = str(value, encoding=locale.getpreferredencoding())
-            except TypeError:
-                pass
-    else:
-        # based on locale.currency() in python >= 2.5
-        conv = locale.localeconv()
-        value = [conv["currency_symbol"], conv["p_sep_by_space"] and " " or "",
-            (("%%.%sf" % conv["frac_digits"]) % value).replace(".",
-            conv["mon_decimal_point"])]
-        if not conv["p_cs_precedes"]:
-            value.reverse()
-        value = "".join(value)
+    value = locale.currency(Decimal(value), grouping=True)
+    if platform.system() == 'Windows':
+        try:
+            value = str(value, encoding=locale.getpreferredencoding())
+        except TypeError:
+            pass
     return value
 
 


### PR DESCRIPTION
Noticed the `currency` template filter in `shop_tags` still had a work around for what looks to be Python 2.4 (which didn't have locale.currency). Since Python required version is all the way up to 2.7 now might as well drop that dead code.
