### PR TITLE
Refactor CartManager.from_request to use update

### DIFF
--- a/cartridge/shop/managers.py
+++ b/cartridge/shop/managers.py
@@ -27,14 +27,16 @@ class CartManager(Manager):
         # Update timestamp and clear out old carts.
         if cart_id and cart.update(last_updated=last_updated):
             self.expired().delete()
-        else:
+        elif cart_id:
             try:
                 request.session["cart"] = None
                 # Forget what checkout step we were up to.
                 del request.session["order"]["step"]
-                request.session.modified = True
             except KeyError:
                 pass
+        # Since we're being clever and hand-building the small cart
+        # model, make sure it has the number of fields as we think
+        assert len(self.model._meta.fields) == 2
         return self.model(id=cart_id, last_updated=last_updated)
 
     def expiry_time(self):


### PR DESCRIPTION
Uses one less database round trip if a cart exists (`UPDATE`, `DELETE` vs `SELECT`, `UPDATE`, `DELETE`) and consolidates the code a bit.

Also closes a possible race condition where a cart right on the edge of expiration would be selected, then expire and deleted by a different request, before saving in the original request (which would cause an `UPDATE` (failure) and then `INSERT`). This race condition was dastardly as there's also the possibility that the cart would be selected, expire and deleted, a new cart created which would take the old ID (if the original cart was the highest ID cart) and then the old cart and the new cart would have the same ID being used by two different sessions.