### PR TITLE
Avoid extra DB dip in cart template

### DIFF
--- a/cartridge/shop/templates/shop/cart.html
+++ b/cartridge/shop/templates/shop/cart.html
@@ -11,7 +11,8 @@
 {% endblock %}
 
 {% block main %}
-{% if request.cart.has_items %}
+{# Don't use request.cart.has_items to avoid extra DB dip #}
+{% if cart_formset.forms|length %}
 <form method="post" class="cart-form">
 {% csrf_token %}
 {% if cart_formset.errors %}


### PR DESCRIPTION
In cart template, `request.cart.has_items` and `cart_formset.forms` both cause the same DB query to be executed. There's no way to cause them to use each other's results, so avoid `request.cart.has_items`, we can infer the same info from the number of forms on the formset.