### PR TITLE
Change set_locale to only catch locale.Error

### DIFF
--- a/cartridge/shop/utils.py
+++ b/cartridge/shop/utils.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 from future.builtins import bytes, zip, str as _str
 
 import hmac
-from locale import setlocale, LC_MONETARY
+from locale import setlocale, LC_MONETARY, Error as LocaleError
 
 try:
     from hashlib import sha512 as digest
@@ -104,8 +104,8 @@ def set_locale():
     try:
         if setlocale(LC_MONETARY, currency_locale) == "C":
             # C locale doesn't contain a suitable value for "frac_digits".
-            raise
-    except:
+            raise LocaleError
+    except LocaleError:
         msg = _("Invalid currency locale specified for SHOP_CURRENCY_LOCALE: "
                 "'%s'. You'll need to set the locale for your system, or "
                 "configure the SHOP_CURRENCY_LOCALE setting in your settings "


### PR DESCRIPTION
Currently `set_locale` will swallow other exceptions out of `locale.setlocale` since it catches everything. This can lead to very confusing debugging. I ran into an issue where there was a ValueError being raised due to an encoding problem on the value for `SHOP_CURRENCY_LOCALE`, and it was being swallowed up here.

Change is fairly simple and I believe keeps the current behavior, but will let unexpected exceptions through.
