### PR TITLE
Limit shop category page processor to exact page

### DIFF
--- a/cartridge/shop/page_processors.py
+++ b/cartridge/shop/page_processors.py
@@ -9,7 +9,7 @@ from mezzanine.utils.views import paginate
 from cartridge.shop.models import Category, Product
 
 
-@processor_for(Category)
+@processor_for(Category, exact_page=True)
 def category_processor(request, page):
     """
     Add paging/sorting to the products for the category.


### PR DESCRIPTION
Is there any potential downside to this minor change? Seems safe enough, but I don't have much experience with the page processors.

I ran into this in a setup where the 'shop' slug is a shop category to display all products, and then there's a few nested category pages. This helps make nice breadcrumb links ("Home / Shop / Category A") in addition to having an all products page.

However, due to this category page processor not being exact only, that causes it to run for any page under the 'shop/' URL prefix, even if it's not a category page. I found this was adding about 10ms to each request for things like cart and product pages in production, so definitely worthy of snipping.
