### PR TITLE
Add database indexing to order.key

### DIFF
--- a/cartridge/shop/migrations/0006_auto_20150916_0459.py
+++ b/cartridge/shop/migrations/0006_auto_20150916_0459.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shop', '0005_auto_20150527_1127'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='order',
+            name='key',
+            field=models.CharField(max_length=40, db_index=True),
+        ),
+    ]

--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -412,7 +412,7 @@ class Order(SiteRelated):
     additional_instructions = models.TextField(_("Additional instructions"),
                                                blank=True)
     time = models.DateTimeField(_("Time"), auto_now_add=True, null=True)
-    key = CharField(max_length=40)
+    key = CharField(max_length=40, db_index=True)
     user_id = models.IntegerField(blank=True, null=True)
     shipping_type = CharField(_("Shipping type"), max_length=50, blank=True)
     shipping_total = fields.MoneyField(_("Shipping total"))


### PR DESCRIPTION
Once you get past a few thousand orders, lookups by `Order.key` start getting expensive, so use an index to speed things up.
