### PR TITLE
Changed reference in initial_form_data to form_class

### DIFF
--- a/cartridge/shop/checkout.py
+++ b/cartridge/shop/checkout.py
@@ -130,7 +130,7 @@ def initial_order_data(request, form_class=None):
             user_models.insert(0, get_profile_for_user(request.user))
         except ProfileNotConfigured:
             pass
-        for order_field in OrderForm._meta.fields:
+        for order_field in form_class._meta.fields:
             check_fields = [order_field]
             for prefix in ("billing_detail_", "shipping_detail_"):
                 if order_field.startswith(prefix):


### PR DESCRIPTION
Cartrige allows using custom order forms. The class used as order form is passed to initial_form_data as the parameter 'form_class'. However, in the current source code only fields defined in the default 'OrderForm' are accessed resulting in the fact that fields defined in customized order forms are never pre-filled. Changing the reference in line 133 from 'OrderForm' to 'form_class' will solve this issue.

Chris