### PR TITLE
Added Python 3.5 to trove classifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,15 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 matrix:
   exclude:
      - python: "2.7"
        env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.8.x.zip
+     - python: "3.5"
+       env: DJANGO_VERSION=https://github.com/django/django/archive/stable/1.7.x.zip
 install:
-  - pip install $DJANGO_VERSION --use-mirrors
+  - pip install $DJANGO_VERSION
   - pip install -e git://github.com/stephenmcd/mezzanine.git#egg=mezzanine
   - pip install . --allow-unverified pyPdf
 script:

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ try:
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.3",
             "Programming Language :: Python :: 3.4",
+            "Programming Language :: Python :: 3.5",
             "Topic :: Internet :: WWW/HTTP",
             "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
             "Topic :: Internet :: WWW/HTTP :: WSGI",


### PR DESCRIPTION
As of 9ba1956, Cartridge appears to fully support Python 3.5. I have tested this with a large, functioning Mezzanine+Cartridge site.

Ties in with [mezzanine/#1476](https://github.com/stephenmcd/mezzanine/pull/1476)