### PR TITLE
Make example work with python 3

### DIFF
--- a/cartridge/shop/payment/paypal.py
+++ b/cartridge/shop/payment/paypal.py
@@ -46,7 +46,8 @@ def process(request, order_form, order):
 
     class MyOrderForm(OrderForm):
         def __init__(self, *args, **kwargs):
-            super(OrderForm, self).__init__(*args, **kwrds)
+            super(OrderForm, self).__init__(*args, **kwargss) # Python 2
+            super(MyOrderForm, self).__init__(*args, **kwargs)# Python 3
             billing_country = forms.Select(choices=COUNTRIES)
             shipping_country = forms.Select(choices=COUNTRIES)
             self.fields['billing_detail_country'].widget = billing_country


### PR DESCRIPTION
Modify example so work in python 3. Because of the new and old style classes super is used differently. Being a noob this may be an issue.