### PR TITLE
Added missing context update for cart view extra_context

### DIFF
--- a/cartridge/shop/views.py
+++ b/cartridge/shop/views.py
@@ -196,6 +196,7 @@ def cart(request, template="shop/cart.html",
         if valid:
             return redirect("shop_cart")
     context = {"cart_formset": cart_formset}
+    context.update(extra_context or {})
     settings.use_editable()
     if (settings.SHOP_DISCOUNT_FIELD_IN_CART and
             DiscountCode.objects.active().exists()):


### PR DESCRIPTION
Pull #249 added extra_context to view functions (thank you @dsanders11); however, one view was missed (the cart view). This patch merges the extra_context into the context in the same way as the other views. Since this is only one line of code, I didn't create an issue for it. I hope that's okay.