### PR TITLE
Changing URL for cartridge_braintree extension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -273,7 +273,7 @@ Sites Using Cartridge
 
 .. THIRD PARTY LIBS
 
-.. _`cartridge_braintree`: https://github.com/molokov/cartridge_braintree
+.. _`cartridge_braintree`: https://github.com/henri-hulski/cartridge_braintree
 .. _`cartridge-external-payment`: https://github.com/thomasWajs/cartridge-external-payment
 .. _`cartridge-tax`: https://github.com/kenbolton/cartridge-tax
 .. _`cartridge-stripe`: https://github.com/readevalprint/cartridge-stripe


### PR DESCRIPTION
I'm no longer maintaining cartridge_braintree, and Henri Hulski has offered to take it over, so I've transferred the repository to him.