### PR TITLE
Wrap invoice PDF call with HAS_PDF in case pisa None

### DIFF
--- a/cartridge/shop/views.py
+++ b/cartridge/shop/views.py
@@ -382,7 +382,7 @@ def invoice(request, order_id, template="shop/order_invoice.html",
     context.update(order.details_as_dict())
     context.update(extra_context or {})
     context = RequestContext(request, context)
-    if request.GET.get("format") == "pdf":
+    if HAS_PDF and request.GET.get("format") == "pdf":
         response = HttpResponse(content_type="application/pdf")
         name = slugify("%s-invoice-%s" % (settings.SITE_TITLE, order.id))
         response["Content-Disposition"] = "attachment; filename=%s.pdf" % name


### PR DESCRIPTION
If pisa cannot be imported, it is set to `None` in the following:

```python
try:
    from xhtml2pdf import pisa
except (ImportError, SyntaxError):
    pisa = None
HAS_PDF = pisa is not None
```

Through the use of the `HAS_PDF` variable, PDF links are hidden from the order history pages however if someone were to manually append `?format=pdf` to an invoice URL you get an exception because the `pisa` variable is None.

This patch fixes the exception by silently ignoring the request to show a PDF format invoice if that capability is not available. The standard HTML invoice page is rendered instead.