### PR TITLE
Fix for broken carts on expiration

### DIFF
--- a/cartridge/shop/managers.py
+++ b/cartridge/shop/managers.py
@@ -30,6 +30,7 @@ class CartManager(Manager):
             # Cart has expired. Delete the cart id and
             # forget what checkout step we were up to.
             del request.session["cart"]
+            cart_id = None
             try:
                 del request.session["order"]["step"]
             except KeyError:


### PR DESCRIPTION
This is fixing a bug I introduced by accident with the 'cheeky' method of saving a DB call as @AlexHill put it. Expired carts would still get created on the session with the same ID because the ID was never blanked out, leading to issues with that request trying to add items to a cart ID that no longer exists in the DB (or may actually hit another if the IDs are reused like in sqlite3).