### PR TITLE
Support setting SHOP_PRODUCT_SORT_OPTIONS = ().

### DIFF
--- a/cartridge/shop/page_processors.py
+++ b/cartridge/shop/page_processors.py
@@ -19,7 +19,8 @@ def category_processor(request, page):
                                 ).filter(page.category.filters()).distinct()
     sort_options = [(slugify(option[0]), option[1])
                     for option in settings.SHOP_PRODUCT_SORT_OPTIONS]
-    sort_by = request.GET.get("sort", sort_options[0][1])
+    sort_by = request.GET.get(
+        "sort", sort_options[0][1] if sort_options else '-date_added')
     products = paginate(products.order_by(sort_by),
                         request.GET.get("page", 1),
                         settings.SHOP_PER_PAGE_CATEGORY,

--- a/cartridge/shop/templates/pages/category.html
+++ b/cartridge/shop/templates/pages/category.html
@@ -40,6 +40,7 @@
 
 {% if products.paginator.count != 0 %}
 
+{% if settings.SHOP_PRODUCT_SORT_OPTIONS.count > 0 %}
 <form class="product-sorting" role="form">
     <div class="form-group">
     <label class="control-label" for="sorting-select">{% trans "Sort by" %}</label>
@@ -55,6 +56,7 @@
         </select>
     </div>
 </form>
+{% endif %}
 
 <div class="row product-list">
 {% for product in products.object_list %}


### PR DESCRIPTION
- If empty, sort category pages by the current default '-date_added' by
  default.
- If empty, don't display the product sorting form.