### PR TITLE
Fix "Resend Order Email" button on complete view.

### DIFF
--- a/cartridge/shop/views.py
+++ b/cartridge/shop/views.py
@@ -409,7 +409,6 @@ def order_history(request, template="shop/order_history.html",
     return TemplateResponse(request, template, context)
 
 
-@login_required
 def invoice_resend_email(request, order_id):
     """
     Re-sends the order complete email for the given order and redirects


### PR DESCRIPTION
It currently 404's because the user isn't logged in. Surely I'm missing
something here. Both the `login_required` decorator and the button on
the completion page were present in the initial commit of this view.