### PR TITLE
Remove usages of deprecated settings.use_editable.

### DIFF
--- a/cartridge/shop/checkout.py
+++ b/cartridge/shop/checkout.py
@@ -35,7 +35,7 @@ def default_billship_handler(request, order_form):
     accessible via ``request.cart``
     """
     if not request.session.get("free_shipping"):
-        settings.use_editable()
+        settings.clear_cache()
         set_shipping(request, _("Flat rate shipping"),
                      settings.SHOP_DEFAULT_SHIPPING_VALUE)
 
@@ -50,7 +50,6 @@ def default_tax_handler(request, order_form):
     ``cartridge.shop.utils.set_tax``. The Cart object is also
     accessible via ``request.cart``
     """
-    settings.use_editable()
     set_tax(request, _("Tax"), 0)
 
 
@@ -164,7 +163,7 @@ def send_order_email(request, order):
     """
     Send order receipt email on successful order.
     """
-    settings.use_editable()
+    settings.clear_cache()
     order_context = {"order": order, "request": request,
                      "order_items": order.items.all()}
     order_context.update(order.details_as_dict())

--- a/cartridge/shop/forms.py
+++ b/cartridge/shop/forms.py
@@ -357,7 +357,7 @@ class OrderForm(FormsetForm, DiscountForm):
 
         # Hide discount code field if it shouldn't appear in checkout,
         # or if no discount codes are active.
-        settings.use_editable()
+        settings.clear_cache()
         if not (settings.SHOP_DISCOUNT_FIELD_IN_CHECKOUT and
                 DiscountCode.objects.active().exists()):
             self.fields["discount_code"].widget = forms.HiddenInput()

--- a/cartridge/shop/page_processors.py
+++ b/cartridge/shop/page_processors.py
@@ -14,7 +14,7 @@ def category_processor(request, page):
     """
     Add paging/sorting to the products for the category.
     """
-    settings.use_editable()
+    settings.clear_cache()
     products = Product.objects.published(for_user=request.user
                                 ).filter(page.category.filters()).distinct()
     sort_options = [(slugify(option[0]), option[1])

--- a/cartridge/shop/tests.py
+++ b/cartridge/shop/tests.py
@@ -519,7 +519,7 @@ class TaxationTests(TestCase):
         Ensure that the handler specified in default settings exists as well as
         the default setting itself.
         """
-        settings.use_editable()
+        settings.clear_cache()
         handler = lambda s: import_dotted_path(s) if s else lambda *args: None
         self.assertTrue(handler(settings.SHOP_HANDLER_TAX) is not None)
 

--- a/cartridge/shop/views.py
+++ b/cartridge/shop/views.py
@@ -197,7 +197,7 @@ def cart(request, template="shop/cart.html",
             return redirect("shop_cart")
     context = {"cart_formset": cart_formset}
     context.update(extra_context or {})
-    settings.use_editable()
+    settings.clear_cache()
     if (settings.SHOP_DISCOUNT_FIELD_IN_CART and
             DiscountCode.objects.active().exists()):
         context["discount_form"] = discount_form


### PR DESCRIPTION
I removed the instance in `default_tax_handler` because it doesn't seem
to serve any purpose.

In every other instance I switched to `settings.clear_cache`. I don't
know if this is actually necessary in every case but caution suggests
not changing things one doesn't understand.