### PR TITLE
Fix ProductVariation creation when SHOP_USE_VARIATIONS=False

### DIFF
--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -139,7 +139,7 @@ class Product(BaseProduct, Priced, RichText, ContentTyped, AdminThumbMixin):
         self.set_content_model()
         updating = self.id is not None
         super(Product, self).save(*args, **kwargs)
-        if updating and not settings.SHOP_USE_VARIATIONS:
+        if updating and not settings.SHOP_USE_VARIATIONS and self.variations.all():
             default = self.variations.get(default=True)
             self.copy_price_fields_to(default)
 


### PR DESCRIPTION
This fix a bug saving a Product with SHOP_USE_VARIATIONS=False
```
DoesNotExist at /admin/shop/product/add/
ProductVariation matching query does not exist.
Request Method:	POST
Request URL:	http://localhost:9020/admin/shop/product/add/
Django Version:	1.9.11
Exception Type:	DoesNotExist
Exception Value:	
ProductVariation matching query does not exist.
Exception Location:	/usr/local/lib/python3.5/site-packages/django/db/models/query.py in get, line 387
Python Executable:	/usr/local/bin/python
Python Version:	3.5.2
Python Path:	
['/srv/app',
 '/srv/lib/grappelli-safe',
 '/srv/lib/mezzanine',
 '/srv/lib/mezzanine-agenda',
 '/srv/lib/django-eve',
 '/srv/lib/django-prestashop',
 '/srv/lib/cartridge',
 '/usr/local/lib/python35.zip',
 '/usr/local/lib/python3.5',
 '/usr/local/lib/python3.5/plat-linux',
 '/usr/local/lib/python3.5/lib-dynload',
 '/usr/local/lib/python3.5/site-packages']
```