### PR TITLE
Delete cart on last cart item removed

### DIFF
--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -682,6 +682,13 @@ class CartItem(SelectedProduct):
     def get_absolute_url(self):
         return self.url
 
+    def save(self, *args, **kwargs):
+        super(CartItem, self).save(*args, **kwargs)
+
+        # Check if this is the last cart item being removed
+        if self.quantity == 0 and not self.cart.items.exists():
+            self.cart.delete()
+
 
 class OrderItem(SelectedProduct):
     """


### PR DESCRIPTION
There's currently inconsistent behavior between setting the last cart item's quantity to 0 on the cart view, versus using the remove functionality. The latter deletes the cart as well, the former leaves the cart with no items.

When carts are set to hang around for a long time this leads to ghost carts building up in the DB. This is undesirable for a couple different reasons.

Fix is simple, just delete the cart if the last item was deleted via the quantity is 0 mechanism.