### PR TITLE
#317 : use static_lazy instead of static

### DIFF
--- a/cartridge/shop/admin.py
+++ b/cartridge/shop/admin.py
@@ -32,7 +32,6 @@ are then pushed back onto the one variation for the product.
 from copy import deepcopy
 
 from django.contrib import admin
-from django.contrib.admin.templatetags.admin_static import static
 from django.db.models import ImageField
 from django.utils.translation import ugettext_lazy as _
 
@@ -41,6 +40,7 @@ from mezzanine.core.admin import (
     BaseTranslationModelAdmin, ContentTypedAdmin, DisplayableAdmin,
     TabularDynamicInlineAdmin)
 from mezzanine.pages.admin import PageAdmin
+from mezzanine.utils.static import static_lazy as static
 
 from cartridge.shop.fields import MoneyField
 from cartridge.shop.forms import ProductAdminForm, ProductVariationAdminForm


### PR DESCRIPTION
```from mezzanine.utils.static import static_lazy as static``` seems to be the way to go in **mezzanine**.

It fixes my problem, does it make sense for you ?
