### PR TITLE
Fixed bug caused by adding dictionaries instead of values.

### DIFF
--- a/cartridge/shop/views.py
+++ b/cartridge/shop/views.py
@@ -384,8 +384,12 @@ def invoice(request, order_id, template="shop/order_invoice.html",
     except Order.DoesNotExist:
         raise Http404
     context = {"order": order}
-    context.update(order.details_as_dict())
-    context.update(extra_context or {})
+    detail_dict = order.details_as_dict()
+    for key in detail_dict:
+        context[key] = detail_dict[key]
+    extra_context = extra_context or {}
+    for key in extra_context:
+        context[key] = extra_context[key]
     if HAS_PDF and request.GET.get("format") == "pdf":
         response = HttpResponse(content_type="application/pdf")
         name = slugify("%s-invoice-%s" % (settings.SITE_TITLE, order.id))


### PR DESCRIPTION
With the current version of Cartridge if you attempt to generate an invoice it throws an exception.
```
TypeError at /shop/invoice/1/
dict expected at most 1 arguments, got 3
```
This is caused because additional dictionaries are being added to the context variable in the invoice method.

This PR changes the way the key/values are transferred over to the context.

This could be a Python 2.7 vs Python 3 issue, I am not sure. (I am using Python 3).

Similar issue as been seen in the past:
https://groups.google.com/forum/#!topic/mezzanine-users/nv3pxCfuUHI