### PR TITLE
Fix check for showing custom model types in admin

### DIFF
--- a/cartridge/shop/templates/admin/shop/product/change_list.html
+++ b/cartridge/shop/templates/admin/shop/product/change_list.html
@@ -2,7 +2,7 @@
 {% load shop_tags %}
 
 {% block object-tools-items %}
-    {% if content_models.count > 1 %}
+    {% if content_models|length >= 1 %}
         <li>
             {% include "admin/includes/content_typed_change_list.html" %}
         </li>


### PR DESCRIPTION
The select box does not currently show on the /admin/shop/product page when using custom product types as documented in [this thread on the mailing list](https://groups.google.com/forum/#!searchin/mezzanine-users/custom$20products%7Csort:date/mezzanine-users/4iKngK08I-o/6k7YwRVaAQAJ)

This makes the correct length check, additionally it will also show the box when there is only one custom product type.