### PR TITLE
Add requirements to cartridge project_template

### DIFF
--- a/cartridge/project_template/requirements.txt
+++ b/cartridge/project_template/requirements.txt
@@ -1,0 +1,2 @@
+Mezzanine==4.3.1
+Cartridge==0.13.0


### PR DESCRIPTION
Mezzanine provides a `requirements.txt` file in the `project_template`, and is therefore ready to be used with a virtualenv out-of-the-box. Cartridge lacks a `requirements.txt` file, so the Mezzanine `requirements.txt` is used and Cartridge is not automatically installed when using a virtualenv.

For example:

```
$ pip3 install --upgrade git+https://github.com/stephenmcd/mezzanine.git#egg=Mezzanine
$ pip3 install --upgrade git+https://github.com/stephenmcd/cartridge.git#egg=Cartridge
$ mezzanine-project -a cartridge testcartridge
$ cd testcartridge
$ virtualenv -p python3 env
$ source env/bin/activate
$ pip3 install -r requirements.txt
$ python3 manage.py runserver
[...]
ImportError: No module named 'cartridge'
```

This commit adds the missing `requirements.txt` file to the template, and closes #339.