### PR TITLE
Django 2.2 compatibility

### DIFF
--- a/cartridge/project_template/project_name/settings.py
+++ b/cartridge/project_template/project_name/settings.py
@@ -337,7 +337,6 @@ MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 

--- a/cartridge/project_template/project_name/settings.py
+++ b/cartridge/project_template/project_name/settings.py
@@ -306,6 +306,7 @@ INSTALLED_APPS = (
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "django.contrib.messages",
     "django.contrib.redirects",
     "django.contrib.sessions",
     "django.contrib.sites",

--- a/cartridge/shop/admin.py
+++ b/cartridge/shop/admin.py
@@ -33,6 +33,7 @@ from copy import deepcopy
 
 from django.contrib import admin
 from django.db.models import ImageField
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 
 from mezzanine.conf import settings

--- a/cartridge/shop/admin.py
+++ b/cartridge/shop/admin.py
@@ -297,7 +297,7 @@ def address_pairs(fields):
 order_list_display = ("id", "billing_name", "total", "time", "status",
                       "transaction_id")
 if HAS_PDF:
-    order_list_display += ("invoice",)
+    order_list_display += ("invoice_url",)
 
 
 class OrderAdmin(admin.ModelAdmin):
@@ -324,6 +324,11 @@ class OrderAdmin(admin.ModelAdmin):
              ("discount_total", "discount_code"), "item_total",
             ("total", "status"), "transaction_id")}),
     )
+
+    def invoice_url(self, obj):
+        return format_html(obj.invoice())
+
+    invoice_url.short_description = 'Invoice'
 
     def change_view(self, *args, **kwargs):
         if kwargs.get("extra_context", None) is None:

--- a/cartridge/shop/checkout.py
+++ b/cartridge/shop/checkout.py
@@ -106,7 +106,7 @@ def initial_order_data(request, form_class=None):
     # Look for order in previous session.
     if not initial:
         lookup = {}
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             lookup["user_id"] = request.user.id
         remembered = request.COOKIES.get("remember", "").split(":")
         if len(remembered) == 2 and remembered[0] == sign(remembered[1]):
@@ -115,7 +115,7 @@ def initial_order_data(request, form_class=None):
             previous = list(Order.objects.filter(**lookup).values())[:1]
             if len(previous) > 0:
                 initial.update(previous[0])
-    if not initial and request.user.is_authenticated():
+    if not initial and request.user.is_authenticated:
         # No previous order data - try and get field values from the
         # logged in user. Check the profile model before the user model
         # if it's configured. If the order field name uses one of the

--- a/cartridge/shop/forms.py
+++ b/cartridge/shop/forms.py
@@ -438,7 +438,7 @@ class ImageWidget(forms.FileInput):
     """
     Render a visible thumbnail for image fields.
     """
-    def render(self, name, value, attrs):
+    def render(self, name, value, attrs, renderer=None):
         rendered = super(ImageWidget, self).render(name, value, attrs)
         if value:
             orig = u"%s%s" % (settings.MEDIA_URL, value)
@@ -453,7 +453,7 @@ class MoneyWidget(forms.TextInput):
     """
     Render missing decimal places for money fields.
     """
-    def render(self, name, value, attrs):
+    def render(self, name, value, attrs, renderer=None):
         try:
             value = float(value)
         except (TypeError, ValueError):

--- a/cartridge/shop/managers.py
+++ b/cartridge/shop/managers.py
@@ -79,7 +79,7 @@ class OrderManager(CurrentSiteManager):
         the given request object can access it.
         """
         lookup = {"id": order_id}
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             lookup["key"] = request.session.session_key
         elif not request.user.is_staff:
             lookup["user_id"] = request.user.id

--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -145,7 +145,7 @@ class Product(BaseProduct, Priced, RichText, ContentTyped, AdminThumbMixin):
 
     @models.permalink
     def get_absolute_url(self):
-        return ("shop_product", (), {"slug": self.slug})
+        return reverse("shop_product", kwargs={"slug": self.slug})
 
     def copy_default_variation(self):
         """

--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -143,7 +143,6 @@ class Product(BaseProduct, Priced, RichText, ContentTyped, AdminThumbMixin):
             default = self.variations.get(default=True)
             self.copy_price_fields_to(default)
 
-    @models.permalink
     def get_absolute_url(self):
         return reverse("shop_product", kwargs={"slug": self.slug})
 

--- a/cartridge/shop/tests.py
+++ b/cartridge/shop/tests.py
@@ -7,10 +7,10 @@ from operator import mul
 from functools import reduce
 from unittest import skipUnless
 
-from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.utils.timezone import now
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from mezzanine.conf import settings
 from mezzanine.core.models import CONTENT_STATUS_PUBLISHED

--- a/cartridge/shop/views.py
+++ b/cartridge/shop/views.py
@@ -5,7 +5,7 @@ from json import dumps
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.messages import info
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import Sum
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect

--- a/cartridge/shop/views.py
+++ b/cartridge/shop/views.py
@@ -218,7 +218,7 @@ def checkout_steps(request, form_class=OrderForm, extra_context=None):
     # Do the authentication check here rather than using standard
     # login_required decorator. This means we can check for a custom
     # LOGIN_URL and fall back to our own login view.
-    authenticated = request.user.is_authenticated()
+    authenticated = request.user.is_authenticated
     if settings.SHOP_CHECKOUT_ACCOUNT_REQUIRED and not authenticated:
         url = "%s?next=%s" % (settings.LOGIN_URL, reverse("shop_checkout"))
         return redirect(url)


### PR DESCRIPTION
When used in combination with Mezzanine==5.0.0a1, these updates allow Cartridge to work with Django 2.2, a supported LTS version of Django until April 2022.

Thanks to @petedermott for getting this started. Not all of those changes worked in my case, but I stripped back a few and also found a few other improvements, and it worked in my project after that.