### PR TITLE
Adding SHOP_TAX_INCLUDED setting

### DIFF
--- a/cartridge/shop/defaults.py
+++ b/cartridge/shop/defaults.py
@@ -346,3 +346,11 @@ register_setting(
     editable=False,
     default=True,
 )
+
+register_setting(
+    name="SHOP_TAX_INCLUDED",
+    label=_("Tax included"),
+    description="The product prices are already including tax (boolean).",
+    editable=False,
+    default=False,
+)

--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -532,7 +532,7 @@ class Order(SiteRelated):
             self.total += self.shipping_total
         if self.discount_total is not None:
             self.total -= Decimal(self.discount_total)
-        if self.tax_total is not None:
+        if self.tax_total is not None and not settings.SHOP_TAX_INCLUDED:
             self.total += Decimal(self.tax_total)
         self.save()  # We need an ID before we can add related items.
         for item in request.cart:

--- a/cartridge/shop/templates/shop/includes/order_totals.html
+++ b/cartridge/shop/templates/shop/includes/order_totals.html
@@ -14,17 +14,6 @@
         </label> <span>{{ discount_total|currency }}</span>
     </div>
     {% endif %}
-    {% if shipping_type or shipping_total %}
-    <div>
-        <label>
-        {% if shipping_type %}
-        {{ shipping_type }}:
-        {% else %}
-        {% trans "Shipping" %}:
-        {% endif %}
-        </label> <span>{{ shipping_total|currency }}</span>
-    </div>
-    {% endif %}
     {% if tax_total %}
     <div>
         <label>
@@ -34,6 +23,17 @@
         {% trans "Tax" %}:
         {% endif %}
         </label> <span>{{ tax_total|currency }}</span>
+    </div>
+    {% endif %}
+    {% if shipping_type or shipping_total %}
+    <div>
+        <label>
+        {% if shipping_type %}
+        {{ shipping_type }}:
+        {% else %}
+        {% trans "Shipping" %}:
+        {% endif %}
+        </label> <span>{{ shipping_total|currency }}</span>
     </div>
     {% endif %}
     <div class="total"><label>{% trans "Total" %}:</label> <span>{{ order_total|currency }}</span></div>

--- a/cartridge/shop/templatetags/shop_tags.py
+++ b/cartridge/shop/templatetags/shop_tags.py
@@ -3,6 +3,7 @@ import platform
 from decimal import Decimal
 
 from django import template
+from mezzanine.conf import settings
 
 from cartridge.shop.utils import set_locale
 
@@ -60,7 +61,10 @@ def _order_totals(context):
         template_vars["order_total"] += Decimal(str(template_vars["shipping_total"]))
     if template_vars.get("discount_total", None) is not None:
         template_vars["order_total"] -= Decimal(str(template_vars["discount_total"]))
-    if template_vars.get("tax_total", None) is not None:
+    if (
+        template_vars.get("tax_total", None) is not None
+        and not settings.SHOP_TAX_INCLUDED
+    ):
         template_vars["order_total"] += Decimal(str(template_vars["tax_total"]))
     return template_vars
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -96,26 +96,9 @@ will then appear in the totals for the order::
 Just as with shipping, the ``tax_type`` variable is simply a string
 label, so using a value such as "Tax" here will usually suffice.
 
-.. note::
-
-    This tax implementation is geared towards countries where tax is
-    not included in a product's price, and therefore should be added
-    separately to the overall order total.
-
-    Some countries however generally include tax in a product's price.
-    In this case you may still need to display the tax amount in the
-    order totals, purely for informational purposes without it having
-    any bearing on the overall order total (which will already include
-    the tax amount, given its a sum of all products ordered).
-
-    In the latter case, the easiest approach to displaying tax without
-    it affecting the order total is to simply override the templates
-    ``shop/includes/order_totals.html`` and
-    ``shop/includes/order_totals.txt``, and include in these a template
-    tag that calculates the tax amount for display purposes. These
-    templates are responsible for displaying the order totals in all
-    cases, such as the cart, checkout, and the order receipt emails and
-    PDF downloads.
+If you live in a country, where tax is already included in a product's
+price set the ``SHOP_TAX_INCLUDED`` setting to true.
+In this case the tax will not be added to the overall order total.
 
 Payment
 =======

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -251,3 +251,12 @@ Default: ``True``
 Show the links to the wishlist, and allow adding products to it.
 
 Default: ``True``
+
+.. _SHOP_TAX_INCLUDED:
+
+``SHOP_TAX_INCLUDED``
+---------------------
+
+The product prices are already including tax (boolean).
+
+Default: ``False``


### PR DESCRIPTION
This PR adds the SHOP_TAX_INCLUDED setting for countries where tax is already included in the product price.
It defaults to `false`, so it behave the same as before.
The PR changes also the order of tax and shipping totals in the order table to make it more obvious to which total the tax belong.
I will add some documentation.