### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Features
 * Smart categories (by price range, colour, etc)
 * Registered or anonymous checkout
 * Configurable number of checkout steps
-* Denormalised data for accessiblilty and performance
+* Denormalised data for accessibility and performance
 * Authenticated customer accounts with transaction history
 
 Dependencies

--- a/cartridge/shop/fields.py
+++ b/cartridge/shop/fields.py
@@ -1,6 +1,6 @@
 """
 Various model fields that mostly provide default field sizes to ensure
-these are consistant when used across multiple models.
+these are consistent when used across multiple models.
 """
 
 from locale import localeconv

--- a/cartridge/shop/management/commands/product_db.py
+++ b/cartridge/shop/management/commands/product_db.py
@@ -17,7 +17,7 @@ from cartridge.shop.models import (
     ProductVariation,
 )
 
-# images get copied from thie directory
+# images get copied from this directory
 LOCAL_IMAGE_DIR = "/tmp/orig"
 # images get copied to this directory under STATIC_ROOT
 IMAGE_SUFFIXES = [

--- a/cartridge/shop/models.py
+++ b/cartridge/shop/models.py
@@ -212,7 +212,7 @@ class ProductOption(models.Model):
 
 class ProductVariationMetaclass(ModelBase):
     """
-    Metaclass for the ``ProductVariation`` model that dynamcally
+    Metaclass for the ``ProductVariation`` model that dynamically
     assigns an ``fields.OptionField`` for each option in the
     ``SHOP_PRODUCT_OPTIONS`` setting.
     """
@@ -678,7 +678,7 @@ class Cart(models.Model):
             return discount.calculate(self.total_price())
         total = Decimal("0")
         # Create a list of skus in the cart that are applicable to
-        # the discount, and total the discount for appllicable items.
+        # the discount, and total the discount for applicable items.
         lookup = {"product__in": products, "sku__in": self.skus()}
         discount_variations = ProductVariation.objects.filter(**lookup)
         discount_skus = discount_variations.values_list("sku", flat=True)

--- a/tests/test_shop.py
+++ b/tests/test_shop.py
@@ -408,7 +408,7 @@ class SaleTests(TestCase):
         """
         Regression test for GitHub issue #24. Incorrect exception handle meant
         that in some cases (usually percentage discount) sale_prices were not
-        being applied to all products and their varitations.
+        being applied to all products and their variations.
 
         Note: This issues was only relevant using MySQL and with exceptions
         turned on (which is the default when DEBUG=True).


### PR DESCRIPTION
There are small typos in:
- README.rst
- cartridge/shop/fields.py
- cartridge/shop/management/commands/product_db.py
- cartridge/shop/models.py
- tests/test_shop.py

Fixes:
- Should read `this` rather than `thie`.
- Should read `variations` rather than `varitations`.
- Should read `dynamically` rather than `dynamcally`.
- Should read `consistent` rather than `consistant`.
- Should read `applicable` rather than `appllicable`.
- Should read `accessibility` rather than `accessiblilty`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md